### PR TITLE
Moved radius initialisation outside of the loop

### DIFF
--- a/src/samplers/SamplerDartThrowing.hpp
+++ b/src/samplers/SamplerDartThrowing.hpp
@@ -103,9 +103,9 @@ namespace utk
 			{
 				int iter = 1;
 				bool accept=false;
+				double current_dist = distDT;
 				while( ! accept )
 				{
-					double current_dist = distDT;
 					if(m_relaxed)
 					{
 						if(iter%1000 == 0)


### PR DESCRIPTION
It seemed odd to me that the dist is re-initialized in the while loop, after checking [MCCOOL M., FIUME E.: Hierarchical Poisson disk
sampling distributions.] it seems that the assignation should be out of the loop.