### PR TITLE
Fixing windows pyutk compilation

### DIFF
--- a/externals/ForcedRandom/src/ForcedRandomSampling/main.hpp
+++ b/externals/ForcedRandom/src/ForcedRandomSampling/main.hpp
@@ -13,10 +13,11 @@
 #include "../Common/MathTypes.h"
 #include "../Common/Random.h"
 
-#ifdef WIN32
-#define NOMINMAX
-#include <Windows.h>
-#endif
+//These seem not to be needed and make pyutk compilation fail
+//#ifdef WIN32
+//#define NOMINMAX
+//#include <Windows.h>
+//#endif
 
 // Remove this definition to compile without the OpenCL code
 //#define USEOPENCL


### PR DESCRIPTION
<Windows.h> include failed for duplicated symbols on windows when compiling pyutk
Removing it doesn't seem to change outputs from the forced random sampler